### PR TITLE
Outlook conversation tree

### DIFF
--- a/Entity/TicketConversation.php
+++ b/Entity/TicketConversation.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Webkul\UVDesk\CoreFrameworkBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Webkul\UVDesk\CoreFrameworkBundle\Repository\TicketConversationRepository;
+
+/**
+ * @ORM\Entity(repositoryClass=TicketConversationRepository::class)
+ * @ORM\Table(name="uv_ticket_conversation", indexes={@ORM\Index("uv_ti_co_id", columns={"conversation_id"})})
+ */
+class TicketConversation
+{
+    /**
+     * @ORM\Id()
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Ticket")
+     * @ORM\JoinColumn(name="ticket_id", referencedColumnName="id", onDelete="CASCADE")
+     */
+    private Ticket $ticket;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private string $conversationId = '';
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTicket(): Ticket
+    {
+        return $this->ticket;
+    }
+
+    public function setTicket(Ticket $ticket): TicketConversation
+    {
+        $this->ticket = $ticket;
+
+        return $this;
+    }
+
+    public function getConversationId(): string
+    {
+        return $this->conversationId;
+    }
+
+    public function setConversationId(string $conversationId): TicketConversation
+    {
+        $this->conversationId = $conversationId;
+
+        return $this;
+    }
+
+}

--- a/Repository/TicketConversationRepository.php
+++ b/Repository/TicketConversationRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Webkul\UVDesk\CoreFrameworkBundle\Repository;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Webkul\UVDesk\CoreFrameworkBundle\Entity\TicketConversation;
+
+class TicketConversationRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, TicketConversation::class);
+    }
+
+    public function findOneByConversationId(mixed $conversationId)
+    {
+        return $this->findOneBy(
+            [
+                'conversationId' => $conversationId,
+            ]
+        );
+    }
+
+}

--- a/Utils/Microsoft/Graph/Me.php
+++ b/Utils/Microsoft/Graph/Me.php
@@ -104,7 +104,7 @@ class Me
 
     public static function message(string $id, string $accessToken): array
     {
-        $endpoint = sprintf('%s/messages/%s?$select=internetMessageHeaders', self::BASE_ENDPOINT, $id);
+        $endpoint = sprintf('%s/messages/%s?$select=from,sender,toRecipients,ccRecipients,bccRecipients,internetMessageId,internetMessageHeaders,conversationId,subject,body', self::BASE_ENDPOINT, $id);
 
         $curlHandler = curl_init();
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Mails sent with Microsoft Apps are not Keeping the same conversation Id.

### 2. What does this change do, exactly?

We create a new table to remember the ticket <-> conversationId relation.

### 3. Please link to the relevant issues (if any).

Fix #8 